### PR TITLE
Initial monorepo scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,62 @@
+# Sentinela Publicações Monorepo
+
+Este monorepo reúne todos os serviços do ecossistema Sentinela, responsáveis por coletar, tratar e disponibilizar publicações monitoradas. A estrutura foi organizada para facilitar o desenvolvimento independente de cada serviço enquanto mantém um fluxo de entrega integrado.
+
+## Estrutura dos diretórios
+
+- `scrapy_service/`: serviço de coleta que utiliza spiders Scrapy para buscar publicações nas fontes monitoradas.
+- `api_service/`: serviço de API responsável por disponibilizar os dados normalizados e persistidos para consumo interno e externo.
+- `infrastructure/`: scripts e definições de infraestrutura como código, além de ferramentas de observabilidade e automação de deploy.
+- `docs/`: documentação técnica e operacional do monorepo.
+
+## Requisitos gerais
+
+Cada serviço possui suas próprias dependências para garantir isolamento. Recomenda-se utilizar ambientes virtuais separados (por exemplo, `python -m venv .venv && source .venv/bin/activate`).
+
+## Como executar os serviços
+
+### Scrapy Service
+1. Acesse o diretório do serviço:
+   ```bash
+   cd scrapy_service
+   ```
+2. Crie e ative um ambiente virtual, se necessário.
+3. Instale as dependências:
+   ```bash
+   pip install -r requirements.txt
+   ```
+4. Execute a spider desejada:
+   ```bash
+   scrapy crawl <nome_da_spider>
+   ```
+
+### API Service
+1. Acesse o diretório do serviço:
+   ```bash
+   cd api_service
+   ```
+2. Crie e ative um ambiente virtual, se necessário.
+3. Instale as dependências:
+   ```bash
+   pip install -r requirements.txt
+   ```
+4. Inicie o servidor de desenvolvimento:
+   ```bash
+   uvicorn app.main:app --reload
+   ```
+
+### Infrastructure
+1. Acesse o diretório do serviço:
+   ```bash
+   cd infrastructure
+   ```
+2. Crie e ative um ambiente virtual, se necessário.
+3. Instale as dependências para scripts auxiliares:
+   ```bash
+   pip install -r requirements.txt
+   ```
+4. Execute os scripts de automação disponíveis (por exemplo, provisionamento via Terraform ou ferramentas CLI) conforme descrito na documentação específica do diretório.
+
+## Documentação adicional
+
+Consulte `docs/arquitetura.md` para entender o fluxo completo de dados do coletor até a exposição via API.

--- a/api_service/requirements.txt
+++ b/api_service/requirements.txt
@@ -1,0 +1,4 @@
+# Dependências específicas do serviço de API
+fastapi>=0.110
+uvicorn[standard]>=0.27
+pydantic>=2.5

--- a/docs/arquitetura.md
+++ b/docs/arquitetura.md
@@ -1,0 +1,14 @@
+# Arquitetura do Fluxo de Publicações
+
+```text
+[Coletor Scrapy] --(dados brutos)--> [Pipeline de Normalização] --(dados limpos)--> [Persistência / Banco de Dados]
+          \
+           \--(metadados e logs)--> [Monitoramento]
+
+[Persistência / Banco de Dados] --(consultas)--> [API Service] --(respostas JSON)--> [Consumidores]
+```
+
+1. **Coletor Scrapy**: spiders coletam publicações nas fontes de interesse e enviam os dados para o pipeline de normalização.
+2. **Pipeline de Normalização**: transforma os dados brutos em um formato padronizado, enriquecendo com metadados e verificações de qualidade.
+3. **Persistência**: armazena os dados normalizados em um banco de dados otimizado para consultas rápidas.
+4. **API Service**: expõe endpoints que consomem os dados persistidos e os disponibilizam para sistemas internos, parceiros ou dashboards.

--- a/infrastructure/requirements.txt
+++ b/infrastructure/requirements.txt
@@ -1,0 +1,3 @@
+# Dependências para scripts de infraestrutura e automação
+fabric>=3.2
+python-dotenv>=1.0

--- a/scrapy_service/requirements.txt
+++ b/scrapy_service/requirements.txt
@@ -1,0 +1,3 @@
+# Dependências específicas do serviço Scrapy
+scrapy>=2.11
+itemadapter>=0.8


### PR DESCRIPTION
## Summary
- scaffold project directories for scrapy, api, infrastructure, and shared documentation
- add top-level README describing repository responsibilities and execution steps for each service
- document the architecture flow and establish isolated dependency requirement files for every service

## Testing
- not run (documentation and scaffolding only)


------
https://chatgpt.com/codex/tasks/task_e_68d346d1ecf8832b9311d476c1b4a148