### PR TITLE
Implementar agendamento, logging estruturado e métricas

### DIFF
--- a/api_service/logging_config.py
+++ b/api_service/logging_config.py
@@ -1,0 +1,48 @@
+"""Configuração de logging estruturado para o serviço FastAPI."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Dict
+
+from api_service.run_context import get_run_id
+
+
+class JsonFormatter(logging.Formatter):
+    """Formatter que produz logs em JSON com correlação de run_id."""
+
+    def format(self, record: logging.LogRecord) -> str:  # noqa: D401 - assinatura imposta
+        payload: Dict[str, Any] = {
+            "timestamp": self.formatTime(record, self.datefmt),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+            "run_id": getattr(record, "run_id", get_run_id()),
+        }
+        if record.exc_info:
+            payload["exc_info"] = self.formatException(record.exc_info)
+        if record.stack_info:
+            payload["stack_info"] = self.formatStack(record.stack_info)
+        for key, value in record.__dict__.items():
+            if key.startswith("_") or key in payload:
+                continue
+            if key in {"args", "msg", "message", "levelno", "levelname", "name"}:
+                continue
+            payload[key] = value
+        return json.dumps(payload, ensure_ascii=False)
+
+
+def configure_logging() -> None:
+    """Instala um handler único com formatação JSON."""
+
+    level = os.getenv("API_LOG_LEVEL", "INFO").upper()
+    handler = logging.StreamHandler()
+    handler.setFormatter(JsonFormatter())
+    root_logger = logging.getLogger()
+    root_logger.handlers.clear()
+    root_logger.addHandler(handler)
+    root_logger.setLevel(level)
+
+
+__all__ = ["configure_logging", "JsonFormatter"]

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -1,7 +1,14 @@
 """Aplicação FastAPI principal do serviço de publicações."""
-from fastapi import FastAPI
+from __future__ import annotations
 
+from fastapi import FastAPI
+from prometheus_fastapi_instrumentator import Instrumentator
+
+from api_service.logging_config import configure_logging
+from api_service.middleware import RunIdMiddleware
 from api_service.routers import comments, posts, profiles, runs
+
+configure_logging()
 
 app = FastAPI(
     title="Sentinela Publicações",
@@ -11,6 +18,10 @@ app = FastAPI(
     ),
     version="0.1.0",
 )
+
+app.add_middleware(RunIdMiddleware)
+
+Instrumentator().instrument(app).expose(app, include_in_schema=False)
 
 app.include_router(posts.router)
 app.include_router(comments.router)

--- a/api_service/metrics.py
+++ b/api_service/metrics.py
@@ -1,0 +1,23 @@
+"""Coletores Prometheus específicos do domínio da API."""
+from __future__ import annotations
+
+from prometheus_client import Counter, Histogram
+
+RUNS_LIST_REQUESTS = Counter(
+    "api_runs_list_requests_total",
+    "Quantidade de chamadas ao endpoint de listagem de execuções.",
+)
+RUNS_LIST_FAILURES = Counter(
+    "api_runs_list_failures_total",
+    "Quantidade de falhas ao listar execuções.",
+)
+RUNS_LIST_LATENCY = Histogram(
+    "api_runs_list_latency_seconds",
+    "Latência observada ao listar execuções.",
+)
+
+__all__ = [
+    "RUNS_LIST_REQUESTS",
+    "RUNS_LIST_FAILURES",
+    "RUNS_LIST_LATENCY",
+]

--- a/api_service/middleware.py
+++ b/api_service/middleware.py
@@ -1,0 +1,28 @@
+"""Middlewares auxiliares do serviço de API."""
+from __future__ import annotations
+
+import logging
+import uuid
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from api_service.run_context import bind_run_id
+
+logger = logging.getLogger(__name__)
+
+
+class RunIdMiddleware(BaseHTTPMiddleware):
+    """Garante que toda requisição possua um run_id em contexto."""
+
+    header_name = "X-Run-Id"
+
+    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        run_id = request.headers.get(self.header_name)
+        if not run_id:
+            run_id = str(uuid.uuid4())
+        with bind_run_id(run_id):
+            logger.debug("Processando requisição", extra={"path": request.url.path, "run_id": run_id})
+            response = await call_next(request)
+            response.headers[self.header_name] = run_id
+            return response

--- a/api_service/requirements.txt
+++ b/api_service/requirements.txt
@@ -3,3 +3,5 @@ fastapi>=0.110
 uvicorn[standard]>=0.27
 pydantic>=2.5
 pytest>=8.0
+prometheus-client>=0.20
+prometheus-fastapi-instrumentator>=6.0

--- a/api_service/run_context.py
+++ b/api_service/run_context.py
@@ -1,0 +1,29 @@
+"""Contexto compartilhado para propagação do run_id."""
+from __future__ import annotations
+
+import contextvars
+from contextlib import contextmanager
+from typing import Iterator
+
+_run_id = contextvars.ContextVar("run_id", default="unknown")
+
+
+def get_run_id() -> str:
+    return _run_id.get()
+
+
+def set_run_id(value: str) -> contextvars.Token[str]:
+    return _run_id.set(value)
+
+
+def reset_run_id(token: contextvars.Token[str]) -> None:
+    _run_id.reset(token)
+
+
+@contextmanager
+def bind_run_id(value: str) -> Iterator[None]:
+    token = set_run_id(value)
+    try:
+        yield
+    finally:
+        reset_run_id(token)

--- a/api_service/schemas/runs.py
+++ b/api_service/schemas/runs.py
@@ -19,3 +19,7 @@ class ExecucaoMonitoramento(BaseModel):
     total_publicacoes: int = Field(
         0, ge=0, description="Quantidade de publicações processadas na execução"
     )
+    mensagem_erro: Optional[str] = Field(
+        None,
+        description="Mensagem de erro capturada na execução, quando aplicável",
+    )

--- a/api_service/services/runs.py
+++ b/api_service/services/runs.py
@@ -1,8 +1,10 @@
 """Serviços que tratam informações de execuções de monitoramento."""
 from __future__ import annotations
 
+from time import perf_counter
 from typing import Any, Dict, Iterable, List
 
+from api_service.metrics import RUNS_LIST_FAILURES, RUNS_LIST_LATENCY, RUNS_LIST_REQUESTS
 from api_service.repositories.runs import RunRepository
 from api_service.schemas.runs import ExecucaoMonitoramento
 
@@ -15,19 +17,51 @@ class RunService:
 
     def listar_execucoes(self, limite: int = 50) -> List[ExecucaoMonitoramento]:
         """Lista execuções respeitando o limite informado."""
-
-        registros: Iterable = self._repository.listar_execucoes(limite=limite)
-        return [
-            ExecucaoMonitoramento(**self._converter_para_dict(registro))
-            for registro in registros
-        ]
+        RUNS_LIST_REQUESTS.inc()
+        inicio = perf_counter()
+        try:
+            registros: Iterable = self._repository.listar_execucoes(limite=limite)
+            resultado = [
+                ExecucaoMonitoramento(**self._converter_para_dict(registro))
+                for registro in registros
+            ]
+        except Exception:
+            RUNS_LIST_FAILURES.inc()
+            raise
+        finally:
+            RUNS_LIST_LATENCY.observe(perf_counter() - inicio)
+        return resultado
 
     def _converter_para_dict(self, registro: Any) -> Dict[str, Any]:
         if isinstance(registro, dict):
-            return registro
+            dados: Dict[str, Any] = {}
+            for campo, aliases in {
+                "identificador": ["identificador", "id"],
+                "iniciado_em": ["iniciado_em", "started_at"],
+                "finalizado_em": ["finalizado_em", "finished_at"],
+                "status": ["status"],
+                "total_publicacoes": ["total_publicacoes", "items_collected"],
+                "mensagem_erro": ["mensagem_erro", "error_message"],
+            }.items():
+                for alias in aliases:
+                    if alias in registro:
+                        dados[campo] = registro[alias]
+                        break
+            return dados
 
         dados: Dict[str, Any] = {}
+        aliases = {
+            "identificador": ["identificador", "id"],
+            "iniciado_em": ["iniciado_em", "started_at"],
+            "finalizado_em": ["finalizado_em", "finished_at"],
+            "status": ["status"],
+            "total_publicacoes": ["total_publicacoes", "items_collected"],
+            "mensagem_erro": ["mensagem_erro", "error_message"],
+        }
         for campo in ExecucaoMonitoramento.model_fields:
-            if hasattr(registro, campo):
-                dados[campo] = getattr(registro, campo)
+            candidatos = aliases.get(campo, [campo])
+            for alias in candidatos:
+                if hasattr(registro, alias):
+                    dados[campo] = getattr(registro, alias)
+                    break
         return dados

--- a/docs/operacao.md
+++ b/docs/operacao.md
@@ -1,0 +1,41 @@
+# Operação do coletor Sentinela
+
+## Estratégia de backoff e jitter
+
+O coletor utiliza um middleware de retries com backoff exponencial. Os parâmetros
+podem ser ajustados via variáveis de ambiente:
+
+- `SCRAPY_RETRY_TIMES`: quantidade máxima de tentativas (padrão `5`).
+- `SCRAPY_RETRY_BACKOFF_BASE`: atraso inicial em segundos (padrão `1`).
+- `SCRAPY_RETRY_BACKOFF_MAX`: atraso máximo aplicado ao agendamento das novas
+  tentativas (padrão `60`).
+
+Cada tentativa falha aumenta o delay segundo `delay = min(base * 2^(tentativas-1), max)`.
+Recomenda-se aplicar jitter (ex.: `random.uniform(-0.2, 0.2) * delay`) antes de
+reagendar requisições para evitar sincronia entre múltiplas execuções. Esse jitter
+pode ser implementado ajustando `download_delay` nos metadados da requisição no
+middleware `ExponentialBackoffRetryMiddleware`.
+
+## Limites de concorrência
+
+Os limites globais (`SCRAPY_CONCURRENT_REQUESTS`) e por domínio
+(`SCRAPY_CONCURRENT_PER_DOMAIN`) controlam a quantidade de requisições simultâneas.
+Ajuste-os conforme a capacidade da origem monitorada e a largura de banda
+(distribuição: inicie com `8`/`4` e aumente gradualmente monitorando erros HTTP 429).
+
+Para evitar saturar proxies ou a própria API de origem, combine esses parâmetros com
+`DOWNLOAD_DELAY` (padrão `0`) e o campo `pagination_delay` dos spiders Playwright.
+
+## Rotação de proxies
+
+A rotação é feita pelo middleware `ProxyRotationMiddleware`, que escolhe proxies a
+partir da lista `SCRAPY_PROXIES` (CSV). Recomenda-se manter um pool atualizado e
+executar rotação de credenciais/proxies semanalmente para evitar bloqueios. Em
+ambientes Kubernetes, armazene os proxies em Secrets e atualize-os com rollout
+controlado; em ambientes bare-metal, utilize arquivos de configuração versionados e
+proceda com `ansible`/`scp` para distribuição segura.
+
+1. Atualize a fonte de proxies (Secret ou arquivo).
+2. Reinicie gradualmente os workers (jobs Cron ou pods) para aplicar a nova lista.
+3. Monitore métricas de falhas (`scrapy_run_failures_total`) e códigos de status para
+   validar a eficácia da rotação.

--- a/infrastructure/models/postgres.py
+++ b/infrastructure/models/postgres.py
@@ -124,6 +124,18 @@ class Run(Base):
         nullable=True,
         comment="Contexto adicional ou parâmetros utilizados na execução.",
     )
+    items_collected: Mapped[int] = mapped_column(
+        sa.Integer(),
+        nullable=False,
+        default=0,
+        server_default=sa.text("0"),
+        comment="Quantidade total de itens processados pela execução.",
+    )
+    error_message: Mapped[Optional[str]] = mapped_column(
+        sa.Text(),
+        nullable=True,
+        comment="Mensagem de erro associada à execução, quando existente.",
+    )
 
     profile: Mapped["Profile"] = relationship("Profile", back_populates="runs")
     checkpoints: Mapped[list["Checkpoint"]] = relationship(

--- a/infrastructure/scheduler/README.md
+++ b/infrastructure/scheduler/README.md
@@ -1,0 +1,17 @@
+# Agendamento de coletas
+
+Este diretório contém artefatos prontos para orquestrar a execução do coletor Scrapy.
+O parâmetro `janela_dias` controla quantos dias retroativos devem ser considerados
+na busca de publicações e comentários.
+
+- `cron_trigger.sh`: script pensado para uso com `cron`. Recebe as variáveis de
+  ambiente `RUN_ID`, `PROFILE_ID` e `JANELA_DIAS`. O valor de `RUN_ID` é utilizado
+  para correlação de logs/metricas ao longo de todo o pipeline. `JANELA_DIAS`
+  é repassado para o spider como argumento `-a janela_dias=...`.
+- `collector-cronjob.yaml`: modelo de `CronJob` do Kubernetes. Substitua
+  `{{ profile_id }}` e `{{ janela_dias }}` de acordo com a necessidade. O campo
+  `RUN_ID` é preenchido automaticamente com o UID da execução do job.
+
+Ao ajustar o agendamento, lembre-se de dimensionar a janela temporal (`janela_dias`)
+para evitar sobreposição desnecessária de coletas e reduzir pressão na origem dos
+conteúdos.

--- a/infrastructure/scheduler/collector-cronjob.yaml
+++ b/infrastructure/scheduler/collector-cronjob.yaml
@@ -1,0 +1,40 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: sentinela-coletor
+spec:
+  schedule: "0 */6 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 5
+  jobTemplate:
+    spec:
+      backoffLimit: 3
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: scrapy-coletor
+              image: ghcr.io/organizacao/sentinela-scrapy:latest
+              imagePullPolicy: IfNotPresent
+              env:
+                - name: RUN_ID
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.uid
+                - name: PROFILE_ID
+                  value: "{{ profile_id }}"
+                - name: JANELA_DIAS
+                  value: "{{ janela_dias }}"
+                - name: SCRAPY_SETTINGS_MODULE
+                  value: scrapy_service.settings
+              command:
+                - /bin/sh
+                - -c
+                - >-
+                  scrapy crawl posts \
+                  -s RUN_ID=$RUN_ID \
+                  -a profile_id=$PROFILE_ID \
+                  -a janela_dias=$JANELA_DIAS
+          nodeSelector:
+            sentinela/component: coletor

--- a/infrastructure/scheduler/cron_trigger.sh
+++ b/infrastructure/scheduler/cron_trigger.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Dispara o coletor localmente via cron.
+#
+# Variáveis de ambiente esperadas:
+#   SCRAPY_PROJECT_ROOT - diretório base do projeto.
+#   RUN_ID              - identificador único da execução.
+#   PROFILE_ID          - identificador do perfil a ser coletado.
+#   JANELA_DIAS         - quantidade de dias retroativos considerados.
+#
+# Exemplos de uso no crontab (executa a cada 6 horas):
+#   0 */6 * * * RUN_ID=$(uuidgen) PROFILE_ID=123 \ \
+#       JANELA_DIAS=7 SCRAPY_PROJECT_ROOT=/opt/sentinela \ \
+#       /opt/sentinela/infrastructure/scheduler/cron_trigger.sh >> /var/log/sentinela-cron.log 2>&1
+set -euo pipefail
+
+: "${SCRAPY_PROJECT_ROOT:?Defina SCRAPY_PROJECT_ROOT apontando para o diretório do projeto}" 
+: "${RUN_ID:?Defina RUN_ID para correlacionar logs e métricas}" 
+: "${PROFILE_ID:?Defina PROFILE_ID com o alvo da coleta}" 
+: "${JANELA_DIAS:?Informe JANELA_DIAS para a janela temporal da coleta}" 
+
+cd "$SCRAPY_PROJECT_ROOT"
+
+exec scrapy crawl posts \
+    -s RUN_ID="$RUN_ID" \
+    -a profile_id="$PROFILE_ID" \
+    -a janela_dias="$JANELA_DIAS"

--- a/scrapy_service/requirements.txt
+++ b/scrapy_service/requirements.txt
@@ -5,3 +5,4 @@ itemadapter>=0.8
 pymongo>=4.9
 psycopg[binary]>=3.2
 redis>=5.0
+prometheus-client>=0.20

--- a/scrapy_service/scrapy_service/logging_config.py
+++ b/scrapy_service/scrapy_service/logging_config.py
@@ -1,0 +1,51 @@
+"""Configuração de logging estruturado para o serviço Scrapy."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Dict
+
+from scrapy.utils.log import configure_logging
+
+from scrapy_service.utils.context import get_run_id
+
+
+class JsonFormatter(logging.Formatter):
+    """Formata logs como JSON, incluindo o identificador de execução."""
+
+    def format(self, record: logging.LogRecord) -> str:  # noqa: D401 - interface do logging
+        payload: Dict[str, Any] = {
+            "timestamp": self.formatTime(record, self.datefmt),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+            "run_id": getattr(record, "run_id", get_run_id()),
+        }
+        if record.exc_info:
+            payload["exc_info"] = self.formatException(record.exc_info)
+        if record.stack_info:
+            payload["stack_info"] = self.formatStack(record.stack_info)
+        for key, value in record.__dict__.items():
+            if key.startswith("_") or key in payload:
+                continue
+            if key in {"args", "msg", "message", "levelno", "levelname", "name"}:
+                continue
+            payload[key] = value
+        return json.dumps(payload, ensure_ascii=False)
+
+
+def configure_structured_logging() -> None:
+    """Instala handlers com formatação JSON e nível configurável por ambiente."""
+
+    log_level = os.getenv("SCRAPY_LOG_LEVEL", "INFO").upper()
+    configure_logging(install_root_handler=False)
+    handler = logging.StreamHandler()
+    handler.setFormatter(JsonFormatter())
+    root_logger = logging.getLogger()
+    root_logger.handlers.clear()
+    root_logger.addHandler(handler)
+    root_logger.setLevel(log_level)
+
+
+__all__ = ["configure_structured_logging", "JsonFormatter"]

--- a/scrapy_service/scrapy_service/settings.py
+++ b/scrapy_service/scrapy_service/settings.py
@@ -5,6 +5,11 @@ import json
 import os
 from pathlib import Path
 
+from scrapy_service.logging_config import configure_structured_logging
+from scrapy_service.utils import metrics as _metrics  # noqa: F401 - importa para iniciar servidor
+
+configure_structured_logging()
+
 BOT_NAME = "scrapy_service"
 
 SPIDER_MODULES = ["scrapy_service.spiders"]

--- a/scrapy_service/scrapy_service/utils/__init__.py
+++ b/scrapy_service/scrapy_service/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utilitários compartilhados entre spiders, pipelines e middlewares."""
+
+from .context import bind_run_id, get_run_id, set_run_id
+
+__all__ = ["bind_run_id", "get_run_id", "set_run_id"]

--- a/scrapy_service/scrapy_service/utils/context.py
+++ b/scrapy_service/scrapy_service/utils/context.py
@@ -1,0 +1,30 @@
+"""Contexto compartilhado para execução do coletor."""
+from __future__ import annotations
+
+import contextvars
+import os
+from contextlib import contextmanager
+from typing import Iterator
+
+_run_id = contextvars.ContextVar("run_id", default=os.getenv("RUN_ID", "unknown"))
+
+
+def get_run_id() -> str:
+    """Retorna o identificador da execução em andamento."""
+
+    return _run_id.get()
+
+
+def set_run_id(value: str) -> contextvars.Token[str]:
+    """Define o identificador da execução atual."""
+
+    return _run_id.set(value)
+
+
+@contextmanager
+def bind_run_id(value: str) -> Iterator[None]:
+    token = set_run_id(value)
+    try:
+        yield
+    finally:
+        _run_id.reset(token)

--- a/scrapy_service/scrapy_service/utils/metrics.py
+++ b/scrapy_service/scrapy_service/utils/metrics.py
@@ -1,0 +1,66 @@
+"""Coletores de métricas Prometheus para execuções do Scrapy."""
+from __future__ import annotations
+
+import os
+import time
+from contextlib import contextmanager
+from typing import Iterator
+
+from prometheus_client import Counter, Histogram, start_http_server
+
+from scrapy_service.utils.context import get_run_id
+
+SCRAPY_METRICS_PORT = int(os.getenv("SCRAPY_METRICS_PORT", "9101"))
+SCRAPY_METRICS_ENABLED = os.getenv("SCRAPY_METRICS_ENABLED", "true").lower() in {
+    "1",
+    "true",
+    "yes",
+    "y",
+}
+
+if SCRAPY_METRICS_ENABLED:
+    try:
+        start_http_server(SCRAPY_METRICS_PORT)
+    except OSError:
+        # Servidor já iniciado em outro processo; evita crash em import múltiplo.
+        pass
+
+COLLECTED_ITEMS = Counter(
+    "scrapy_collected_items_total",
+    "Total de itens coletados por spider",
+    labelnames=("spider", "run_id"),
+)
+RUN_DURATION = Histogram(
+    "scrapy_run_duration_seconds",
+    "Tempo total de execução do spider",
+    labelnames=("spider", "run_id"),
+)
+RUN_FAILURES = Counter(
+    "scrapy_run_failures_total",
+    "Falhas registradas por spider",
+    labelnames=("spider", "run_id"),
+)
+
+
+@contextmanager
+def observe_run(spider_name: str) -> Iterator[None]:
+    """Mede o tempo de execução completo de um spider."""
+
+    run_id = get_run_id()
+    start = time.perf_counter()
+    try:
+        yield
+    except Exception:  # pragma: no cover - repropagado após métrica
+        RUN_FAILURES.labels(spider=spider_name, run_id=run_id).inc()
+        raise
+    finally:
+        elapsed = time.perf_counter() - start
+        RUN_DURATION.labels(spider=spider_name, run_id=run_id).observe(elapsed)
+
+
+def register_item(spider_name: str, amount: int = 1) -> None:
+    """Incrementa a contagem de itens coletados."""
+
+    if amount < 1:
+        return
+    COLLECTED_ITEMS.labels(spider=spider_name, run_id=get_run_id()).inc(amount)

--- a/scrapy_service/scrapy_service/utils/runs_logger.py
+++ b/scrapy_service/scrapy_service/utils/runs_logger.py
@@ -1,0 +1,174 @@
+"""Utilitário para registrar execuções de coleta no Postgres."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+import psycopg
+from psycopg import Connection
+
+from scrapy_service.logging_config import configure_structured_logging
+from scrapy_service.utils.context import bind_run_id
+from scrapy_service.utils.metrics import register_item
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RunMetadata:
+    """Metadados mínimos necessários para iniciar uma execução."""
+
+    profile_id: str
+    janela_dias: int
+    run_id: uuid.UUID = field(default_factory=uuid.uuid4)
+    context: Dict[str, Any] = field(default_factory=dict)
+
+
+class RunsLogger:
+    """Gerencia o ciclo de vida de uma execução registrada no banco."""
+
+    def __init__(self, dsn: str | None = None) -> None:
+        self._dsn = dsn or os.getenv("POSTGRES_DSN")
+        if not self._dsn:
+            raise RuntimeError("POSTGRES_DSN não configurado")
+        self._conn: Connection | None = None
+        self._run_id: uuid.UUID | None = None
+        self._items = 0
+        self._started_at: datetime | None = None
+        self._profile_id: Optional[str] = None
+        self._context = None
+
+    def __enter__(self) -> "RunsLogger":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if exc:
+            self.fail(str(exc))
+        else:
+            self.finish()
+
+    def start(self, metadata: RunMetadata) -> uuid.UUID:
+        """Cria o registro inicial da execução."""
+
+        configure_structured_logging()
+        self._conn = psycopg.connect(self._dsn, autocommit=True)
+        self._run_id = metadata.run_id
+        self._profile_id = metadata.profile_id
+        self._started_at = datetime.now(tz=timezone.utc)
+
+        context = {"janela_dias": metadata.janela_dias, **metadata.context}
+        self._context = bind_run_id(str(metadata.run_id))
+        self._context.__enter__()
+        with self._conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO runs (id, profile_id, started_at, status, context, items_collected)
+                VALUES (%s, %s, %s, %s, %s::jsonb, %s)
+                ON CONFLICT (id) DO UPDATE SET
+                    profile_id = EXCLUDED.profile_id,
+                    started_at = EXCLUDED.started_at,
+                    status = EXCLUDED.status,
+                    context = EXCLUDED.context
+                """,
+                (
+                    str(metadata.run_id),
+                    metadata.profile_id,
+                    self._started_at,
+                    "running",
+                    json.dumps(context),
+                    0,
+                ),
+            )
+        logger.info(
+            "Execução iniciada",
+            extra={"profile_id": metadata.profile_id, "janela_dias": metadata.janela_dias},
+        )
+        return metadata.run_id
+
+    def increment_items(self, spider_name: str, amount: int = 1) -> None:
+        """Incrementa o contador interno e emite métrica de coleta."""
+
+        if amount < 1:
+            return
+        self._items += amount
+        register_item(spider_name, amount)
+
+    def finish(self, status: str = "finished") -> None:
+        """Marca a execução como concluída com sucesso."""
+
+        if not self._conn or not self._run_id:
+            return
+        finished_at = datetime.now(tz=timezone.utc)
+        with self._conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE runs
+                SET finished_at = %s,
+                    status = %s,
+                    items_collected = %s,
+                    error_message = NULL
+                WHERE id = %s
+                """,
+                (finished_at, status, self._items, str(self._run_id)),
+            )
+        logger.info(
+            "Execução finalizada",
+            extra={
+                "profile_id": self._profile_id,
+                "items": self._items,
+                "status": status,
+            },
+        )
+        self._cleanup()
+
+    def fail(self, error_message: str) -> None:
+        """Registra falha, mantendo o contador de itens coletados."""
+
+        if not self._conn or not self._run_id:
+            return
+        finished_at = datetime.now(tz=timezone.utc)
+        with self._conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE runs
+                SET finished_at = %s,
+                    status = %s,
+                    items_collected = %s,
+                    error_message = %s
+                WHERE id = %s
+                """,
+                (finished_at, "failed", self._items, error_message[:2000], str(self._run_id)),
+            )
+        error = RuntimeError(error_message)
+        logger.error(
+            "Execução finalizada com erro",
+            extra={
+                "profile_id": self._profile_id,
+                "items": self._items,
+                "error": error_message,
+            },
+        )
+        self._cleanup(error)
+
+    def _cleanup(self, error: Optional[Exception] = None) -> None:
+        if self._conn:
+            self._conn.close()
+        self._conn = None
+        self._run_id = None
+        self._items = 0
+        self._profile_id = None
+        self._started_at = None
+        if self._context:
+            if error:
+                self._context.__exit__(error.__class__, error, None)
+            else:
+                self._context.__exit__(None, None, None)
+            self._context = None
+
+
+__all__ = ["RunsLogger", "RunMetadata"]


### PR DESCRIPTION
## Summary
- adicionar diretório de agendamento com script de cron e manifesto de CronJob documentando o parâmetro `janela_dias`
- configurar logging JSON com correlação por `run_id` e middleware para propagar contexto nos serviços FastAPI e Scrapy
- criar registrador de execuções no Scrapy que atualiza Postgres, emite métricas Prometheus e expõe `/metrics` na API juntamente com contadores/histogramas de runs
- documentar estratégia operacional de backoff, jitter, concorrência e rotação de proxies

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3df57b210832b833bdbc0c619da89